### PR TITLE
Fix: corrected output path for OpenEXR MultiLayer File Output node

### DIFF
--- a/flamenco-manager-example.yaml
+++ b/flamenco-manager-example.yaml
@@ -38,7 +38,7 @@ variables:
     values:
     - platform: all
       value: -b -y
-  storagePath:
+  clientStoragePath:
     values:
     - platform: linux
       value: /mnt/sambashare

--- a/startup_script.py
+++ b/startup_script.py
@@ -130,6 +130,9 @@ def fix_compositing_paths():
 	render_output_path = render_output_path.replace('\\','/')
 	render_output_path = os_path.split(render_output_path)[0]
 
+	if not render_output_path.endswith('/'):
+		render_output_path += "/"
+
 	print("Executing compositor startup fixes.")
 	print(f"Output path: {render_output_path}")
 


### PR DESCRIPTION
When `File Format` in `File Output node` was set to  ` OpenEXR MultiLayer` rendered frames would be saved outside designated folder with full name of that folder and frame number.

Behavior before:
![image](https://github.com/dblanque/flamenco-compositor-script/assets/87319288/58f7ba61-30ae-401a-a9a4-ddfc9bc30f6b)

Behavior after:
![image](https://github.com/dblanque/flamenco-compositor-script/assets/87319288/466546ff-c19f-4d7b-b2f1-90a353d58642)

Blender node setup:
![image](https://github.com/dblanque/flamenco-compositor-script/assets/87319288/ef9bb9ad-15ce-45b4-9309-733f4ff9081e)
